### PR TITLE
Make gitignore test use properly cased filename

### DIFF
--- a/core/src/test/java/dev/jeka/core/api/project/scaffolld/JkProjectScaffoldTest.java
+++ b/core/src/test/java/dev/jeka/core/api/project/scaffolld/JkProjectScaffoldTest.java
@@ -28,12 +28,10 @@ class JkProjectScaffoldTest {
                 .setKind(JkProjectScaffold.Kind.REGULAR)
                 .run();
 
-        // check .gitIgnore
-        if (System.getenv("GITHUB_WORKFLOW") == null) {  // may fail on github action
-            String gitIgnoreContent = JkPathFile.of(baseDir.resolve(".gitIgnore")).readAsString();
-            assertTrue(gitIgnoreContent.contains("/.jeka-work"));
-            assertTrue(gitIgnoreContent.contains("/jeka-output"));
-        }
+        // check .gitignore
+        String gitIgnoreContent = JkPathFile.of(baseDir.resolve(".gitignore")).readAsString();
+        assertTrue(gitIgnoreContent.contains("/.jeka-work"));
+        assertTrue(gitIgnoreContent.contains("/jeka-output"));
 
         // Check Build class is present
         assertTrue(Files.exists(baseDir.resolve(JkConstants.JEKA_SRC_DIR).resolve("Custom.java")));


### PR DESCRIPTION
Otherwise it fails on Linux (such as GitHub runners) because the file cannot be found.